### PR TITLE
fix: 뉴스 기사 관련 api 라우터 로직 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,21 +7,4 @@
   - 만약 외부 호출 api에서 그대로 호출하는 거라면, api route에서 동일 title filtering 하는 util 추가하여 처리
   - 일단 임시 방편으로 컴포넌트 key 값에 index 부여하여 에러 방지
 
-- 문제점2
-  - news 기사 불러올 시, A1면의 맨 첫번쩨 기사를 불러오지 못함
-    - 페이지네이션 설정 관련하여 첫번째 기사를 캐싱한 값을 활용하는 방법이 효율적이지 못하다고 판단됨
-      - <div class="topbox_type6">
-                                  <div>
-                                      <ul>
-                                          <li><a href="?mode=LPOD&mid=sec&oid=009&listType=paper&date=20250201&page=1"
-                                                  class="on nclicks(cnt_order)">A1~A10면</a></li>
-                                          <li><a href="?mode=LPOD&mid=sec&oid=009&listType=paper&date=20250201&page=2"
-                                                  class="nclicks(cnt_order)">A11~A20면</a></li>
-                                          <li><a href="?mode=LPOD&mid=sec&oid=009&listType=paper&date=20250201&page=3"
-                                                  class="nclicks(cnt_order)">A21~A30면</a></li>
-                                      </ul>
-                                  </div>
-                              </div>
-      - 위와 같은 방식으로 신문 페이지를 선택할 수 있도록 html을 제공하므로 이를 활용하는 방법 고안
-
 \*/

--- a/src/app/api/news/getNewsArticle.ts
+++ b/src/app/api/news/getNewsArticle.ts
@@ -2,23 +2,20 @@ import iconv from 'iconv-lite';
 import { redisService } from '@/lib/redisService';
 import { parsingHtml } from './parsingHtml';
 
-export const getNewsArticle = async (url: string, page: string | null) => {
-  /** 쿼리 스트링 값이 page=2 이상일 때만 첨부하여 호출 */
-  const requestUrlWithQueryString =
-    !page || page === '1' ? url : `${url}&page=${page}`;
+export const getNewsArticle = async (date: string, page: string | null) => {
+  const baseUrl = `https://news.naver.com/main/list.naver?mode=LPOD&mid=sec&oid=009&listType=paper&date=${date}`;
+  const requestUrl = page ? `${baseUrl}&page=${page}` : baseUrl;
 
   /** redis에 저장해놓은 데이터가 존재할 경우 */
-  const caching = await redisService.get(requestUrlWithQueryString);
+  const caching = await redisService.get(requestUrl);
 
   if (caching) {
-    return {
-      nextPageRedisKey: requestUrlWithQueryString,
-      articles: JSON.parse(caching),
-    };
+    const { articles, totalPageNum } = JSON.parse(caching);
+    return { articles, totalPageNum };
   }
 
   /** caching 데이터가 존재하지 않을 경우 */
-  const response = await fetch(requestUrlWithQueryString);
+  const response = await fetch(requestUrl);
 
   if (!response.ok) {
     throw new Error(
@@ -28,9 +25,9 @@ export const getNewsArticle = async (url: string, page: string | null) => {
 
   const buffer = await response.arrayBuffer();
   const html = iconv.decode(Buffer.from(buffer), 'EUC-KR'); // UTF-8 방식으로 디코딩
-  const articles = parsingHtml(html); // 기사 제목, 주소, 신문사, 날짜 데이터 parsing
+  const { articles, totalPageNum } = await parsingHtml(html, date); // 뉴스 기사 목록, 전체 페이지 수 parsing
 
   // redis에 caching 처리 후 반환
-  redisService.set(requestUrlWithQueryString, JSON.stringify(articles));
-  return { nextPageRedisKey: requestUrlWithQueryString, articles };
+  redisService.set(requestUrl, JSON.stringify({ articles, totalPageNum }));
+  return { articles, totalPageNum };
 };

--- a/src/app/api/news/parsingHtml.ts
+++ b/src/app/api/news/parsingHtml.ts
@@ -1,40 +1,11 @@
 import { parse } from 'node-html-parser';
+import { parsingArticle, parsingTotalPageNum } from './utils.parsing';
 
-export const parsingHtml = (html: string) => {
+export const parsingHtml = async (html: string, date: string) => {
   const root = parse(html);
 
-  /** 기시 목록이 담긴 div 탐색 (class = list_body.newsflash_body)*/
-  const mainContent = root.querySelector('div.list_body.newsflash_body');
+  const articles = parsingArticle(root);
+  const totalPageNum = await parsingTotalPageNum(root, date);
 
-  if (!mainContent) {
-    console.error("❌ 'list_body.newsflash_body' 요소를 찾을 수 없습니다.");
-    return [];
-  }
-
-  const articles: {
-    title: string; // 기사 제목
-    url: string; // 주소
-    writing: string; // 신문사
-    date: string; // 일자
-  }[] = [];
-
-  mainContent.querySelectorAll('ul li dl').forEach((dtElement) => {
-    const writing =
-      dtElement.querySelector('span.writing')?.textContent.trim() || '';
-    const date = dtElement.querySelector('span.date')?.textContent.trim() || '';
-
-    // dt 내부의 a 태그 탐색 후 title, url 추출
-    const articleLink = dtElement.querySelector('a');
-    if (articleLink) {
-      const title = articleLink.text.trim();
-      const url = articleLink.getAttribute('href') || '';
-
-      if (title && url) {
-        articles.push({ title, url, writing, date });
-      }
-    }
-  });
-
-  /** 일치하는 요소가 없으면 빈 배열 반환 */
-  return articles;
+  return { articles, totalPageNum };
 };

--- a/src/app/api/news/route.ts
+++ b/src/app/api/news/route.ts
@@ -1,45 +1,19 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getNewsArticle } from './getNewsArticle';
-import {
-  plusQueryStringPageNum,
-  isLastPage,
-  generateCurrnetDate,
-} from './utils.news';
-import { redisService } from '@/lib/redisService';
-
-const baseUrl =
-  'https://news.naver.com/main/list.naver?mode=LPOD&mid=sec&oid=009&listType=paper';
+import { generateCurrnetDate, generateResponseData } from './utils.news';
 
 export const GET = async (req: NextRequest) => {
   const { searchParams } = new URL(req.url);
   const page = searchParams.get('page');
-  const requestUrl = `${baseUrl}&date=${generateCurrnetDate()}`;
 
   try {
-    const { articles: curPageArticles } = await getNewsArticle(
-      requestUrl,
+    const { articles, totalPageNum } = await getNewsArticle(
+      generateCurrnetDate(),
       page
     );
 
-    // 요청한 페이지의 다음 페이지 데이터를 요청함
-    const nextPageNumber = plusQueryStringPageNum(page);
-    const { nextPageRedisKey, articles: nextPageArticles } =
-      await getNewsArticle(requestUrl, nextPageNumber);
-
-    // 현재 요청한 페이지가 마지막 페이지인 경우 -> redis에 저장한 다음 페이지 데이터 제거
-    if (await isLastPage({ firstPageRedisKey: requestUrl, nextPageArticles })) {
-      const result = await redisService.delete(nextPageRedisKey);
-      console.log(
-        `[Redis] delete unnecessary data, result: ${result === 1 ? 'success' : 'fail'}`
-      );
-
-      return NextResponse.json({ articles: curPageArticles });
-    }
-
-    // 현재 요청한 페이지가 마지막 페이지가 아닐 경우, next page num을 함께 반환
     return NextResponse.json({
-      articles: curPageArticles,
-      nextPage: nextPageNumber,
+      ...generateResponseData(articles, page, totalPageNum),
     });
   } catch (error) {
     console.error(error);

--- a/src/app/api/news/utils.news.ts
+++ b/src/app/api/news/utils.news.ts
@@ -1,5 +1,3 @@
-import { redisService } from '@/lib/redisService';
-
 /** 오늘 날짜를 계산하는 함수 (yyyymmdd 형식으로 반환) */
 export const generateCurrnetDate = () => {
   const now = new Date();
@@ -13,34 +11,30 @@ export const generateCurrnetDate = () => {
   return koreaTime.replace(/\. /g, '').replace(/\./g, ''); // "yyyy. mm. dd." → "yyyymmdd"
 };
 
-/** 쿼리 스트링으로 전달된 page num에 +1을 더해서 문자열로 반환하는 함수 */
-export const plusQueryStringPageNum = (currentPageNum: string | null) => {
-  if (currentPageNum) {
-    const nextPageNum = Number(currentPageNum) + 1;
-    return String(nextPageNum);
+export const generateResponseData = (
+  articles: [],
+  page: null | string,
+  totalPageNum: null | string
+) => {
+  // 기사 목록이 존재하지 않을 때 -> 빈 배열 반환
+  if (articles.length === 0) {
+    return { articles: [] };
   }
 
-  // page num 관련 query string이 존재하지 않으면, 현재 페이지를 1로 간주 (다음 페이지 2 반환)
-  return String(2);
-};
-
-/** 첫번쨰 페이지와 기사 목록이 일치하는지 체크하는 함수 */
-type ArticlesType = Array<{ title: string }>;
-
-export const isLastPage = async ({
-  firstPageRedisKey,
-  nextPageArticles,
-}: {
-  firstPageRedisKey: string;
-  nextPageArticles: ArticlesType;
-}) => {
-  const caching = await redisService.get(firstPageRedisKey);
-  if (!caching) return;
-
-  const firstPageArticles = await JSON.parse(caching);
-  if (firstPageArticles[0].title === nextPageArticles[0].title) {
-    return true;
+  // page 쿼리 스트링이 존재하지 않을 경우, 1페이지 데이터를 받아옴 -> 다음 페이지 2페이지
+  if (!page) {
+    return { articles, nextPage: 2 };
   }
 
-  return false;
+  // 전체 페에지 수와 비교했을 때, 현재 페이지가 동일하거나 클 경우 nextPage 반환하지 않음
+  if (totalPageNum && Number(page) >= Number(totalPageNum)) {
+    return { articles };
+  }
+
+  // 네이버에서 5페이지 다음에 바로 7페이지로 처리하고 있어서 엣지 케이스 처리 (왜 이렇게 처리하는지 이유는 알 수 없음)
+  if (Number(page) === 5) {
+    return { articles, nextPage: 7 };
+  } else {
+    return { articles, nextPage: Number(page) + 1 };
+  }
 };

--- a/src/app/api/news/utils.parsing.ts
+++ b/src/app/api/news/utils.parsing.ts
@@ -1,0 +1,61 @@
+import { HTMLElement } from 'node-html-parser';
+import { redisService } from '@/lib/redisService';
+
+/** 기사 관련 HTML을 parsing 하는 API */
+export const parsingArticle = (root: HTMLElement) => {
+  // 기시 목록이 담긴 div 탐색 API (class = list_body.newsflash_body)
+  const mainContent = root.querySelector('div.list_body.newsflash_body');
+
+  if (!mainContent) {
+    console.error("❌ 'list_body.newsflash_body' 요소를 찾을 수 없습니다.");
+    return [];
+  }
+
+  const articles: {
+    title: string; // 기사 제목
+    url: string; // 주소
+    writing: string; // 신문사
+    date: string; // 일자
+  }[] = [];
+
+  mainContent.querySelectorAll('ul li dl').forEach((dtElement) => {
+    const writing =
+      dtElement.querySelector('span.writing')?.textContent.trim() || '';
+    const date = dtElement.querySelector('span.date')?.textContent.trim() || '';
+
+    // dt 내부의 a 태그 탐색 후 title, url 추출
+    const articleLink = dtElement.querySelector('a');
+    if (articleLink) {
+      const title = articleLink.text.trim() || '';
+      const url = articleLink.getAttribute('href') || '';
+
+      if (title && url) {
+        articles.push({ title, url, writing, date });
+      }
+    }
+  });
+
+  return articles;
+};
+
+/** 기사 전체 페이지 수 관련  HTML을 parsing 하는 API */
+export const parsingTotalPageNum = async (root: HTMLElement, date: string) => {
+  const totalPageNumKey = `${date}_TOTAL_PAGE_NUM`;
+
+  // caching 된 값이 있는지 확인
+  const cachedTotalPageNum = await redisService.get(totalPageNumKey);
+  if (cachedTotalPageNum) return JSON.parse(cachedTotalPageNum);
+
+  // 없을 경우 parsing
+  const pageList = root.querySelector('div.topbox_type6');
+
+  if (!pageList) {
+    console.error("❌ 'topbox_type6' 요소를 찾을 수 없습니다.");
+    return null;
+  }
+
+  // caching 처리 후 전체 페이지 개수 반환
+  const totalPageNum = pageList.querySelectorAll('a').length;
+  redisService.set(totalPageNumKey, JSON.stringify(totalPageNum));
+  return totalPageNum;
+};


### PR DESCRIPTION
<h3>Result</h3>

- 뉴스 관련 `API` 라우터 수정

<h3>Work list</h3>

- 네이버에서 받아온 `html` 파싱 수행 시, 뉴스 페이지 목록 관련 부분도 처리하여 전체 페이지 수 파악
- `redis` 활용하여 기사 목록 및 전체 페이지 수 캐싱 처리하여 활용
- 네이버 뉴스에서 페이지네이션 관련하여 다소 독특하게 처리하는 부분이 존재하여 엣지 케이스 처리
(`utils.news.ts`에 주석 추가하여 엣지케이스 처리용 함수 구현)